### PR TITLE
fix: use non-capturing group in blockList patterns for Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ export function withMetroConfig(baseConfig, { root, dirname, workspaces }) {
         }
 
         return new RegExp(
-          `^${escape(path.join(dir, 'node_modules', m))}[\/\\\\]`
+          `^${escape(path.join(dir, 'node_modules', m))}(?:[/\\\\])`
         );
       })
     )


### PR DESCRIPTION
Fix for https://github.com/satya164/react-native-monorepo-config/issues/4